### PR TITLE
Don't catch client callback exceptions.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -47,13 +47,14 @@ p.request = function(method, parameters, callback){
 		}else{
 			try{
 				var json = JSON.parse(data);
-				if(json.error){
-					callback(new Error(json.error));
-				}else{
-					callback(null,json);				
-				}
 			}catch(e){ // if the string was not json, we just need to return it
 				callback(null,data);
+				return;
+			}
+			if(json.error){
+				callback(new Error(json.error));
+			}else{
+				callback(null,json);
 			}
 		}
 	});


### PR DESCRIPTION
This makes it easier to debug when a request callback throws an
exception.

Before this changeset, request callback exceptions are caught,
and the exception handler calls the request callback a second time.
