### PR TITLE
Fixed a bug where the callback was called twice for requests that error.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -77,6 +77,7 @@ p.sendRequest = function(method, parameters, callback){
 	request.post({url:"http://"+ this.environment+this.path+"?method="+method, form: parameters}, function (error, response, body) {
 	  if (error || response.statusCode != 200) {
 	  	callback(new Error(error));
+	  	return;
 	  }	
 	  self.logger("info","HTTP Request Successful");
 		var responseData = "";


### PR DESCRIPTION
When a client request errors out, the callback actually gets called twice. This fixes it  by adding a return statement.