### PR TITLE
Omniture API expects a call on https not http

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -74,7 +74,7 @@ p.sendRequest = function(method, parameters, callback){
 	if(self.proxy)
 		options.proxy = self.proxy;	
 	var request = require("request").defaults(options);
-	request.post({url:"http://"+ this.environment+this.path+"?method="+method, form: parameters}, function (error, response, body) {
+	request.post({url:"https://"+ this.environment+this.path+"?method="+method, form: parameters}, function (error, response, body) {
 	  if (error || response.statusCode != 200) {
 	  	callback(new Error(error));
 	  	return;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "https://github.com/imartingraham/nomniture.git"
   },
-  "version": "0.3.10",
+  "version": "0.3.11",
   "author": {
     "name": "Ian Graham",
     "email": "imartingraham@gmail.com",


### PR DESCRIPTION
Prior to https://github.com/imartingraham/nomniture/commit/57007ebfed5ee4a93329010b37d9bdac95c8bc04 the call to omniture was on https rather then http (though confusing as the require was https but the object name was http.) Omniture v1.3 can handle http or https, however version 1.4 requires https.
